### PR TITLE
Add new `Tree#insert(...values)` class method

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -1,4 +1,5 @@
 'use strict';
+const Node = require('./node');
 
 class Tree {
   constructor() {
@@ -7,6 +8,36 @@ class Tree {
 
   get root() {
     return this._root;
+  }
+
+  _insert(node, target) {
+    if (node.value < target.value) {
+      if (target.left) {
+        return this._insert(node, target.left);
+      }
+
+      target.left = node;
+    } else {
+      if (target.right) {
+        return this._insert(node, target.right);
+      }
+
+      target.right = node;
+    }
+  }
+
+  insert(...values) {
+    values.forEach(value => {
+      const {_root} = this;
+      const node = new Node(value);
+
+      if (_root) {
+        return this._insert(node, _root);
+      }
+
+      this._root = node;
+    });
+    return this;
   }
 }
 

--- a/types/bstrie.d.ts
+++ b/types/bstrie.d.ts
@@ -17,6 +17,7 @@ declare namespace tree {
 
   export interface Instance<T> {
     readonly root: node.Instance<T> | null;
+    insert(...values: T[]): this;
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new `n-ary` method: 

- `Tree#insert(...values)`

The method accepts `n` arguments/values and places each one of them at the appropriate location inside the binary search tree.

Also, the corresponding TypeScript ambient declarations are included in the PR.
