### PR TITLE
Add new `Tree#contains(value)` predicate class method

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -26,6 +26,20 @@ class Tree {
     }
   }
 
+  contains(value) {
+    let {_root: current} = this;
+
+    while (current) {
+      if (value === current.value) {
+        return true;
+      }
+
+      current = value < current.value ? current.left : current.right;
+    }
+
+    return false;
+  }
+
   insert(...values) {
     values.forEach(value => {
       const {_root} = this;

--- a/types/bstrie.d.ts
+++ b/types/bstrie.d.ts
@@ -17,6 +17,7 @@ declare namespace tree {
 
   export interface Instance<T> {
     readonly root: node.Instance<T> | null;
+    contains(value: T): boolean;
     insert(...values: T[]): this;
     isEmpty(): boolean;
   }


### PR DESCRIPTION
## Description

The PR introduces the following new unary predicate method: 

- `Tree#contains(value)`

The methods can be used to determine whether the tree includes a certain value among its nodes, returning true or false as appropriate.

Also, the corresponding TypeScript ambient declarations are included in the PR.
