### PR TITLE
Add new `Node#degree` class accessor method

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -7,6 +7,20 @@ class Node {
     this._value = value;
   }
 
+  get degree() {
+    let degree = 0;
+
+    if (this.left) {
+      degree++;
+    }
+
+    if (this.right) {
+      degree++;
+    }
+
+    return degree;
+  }
+
   get left() {
     return this._left;
   }

--- a/types/bstrie.d.ts
+++ b/types/bstrie.d.ts
@@ -1,4 +1,6 @@
 declare namespace node {
+  type Degree = 0 | 1 | 2;
+
   export interface Constructor {
     new <T = any>(value?: T): Instance<T>;
   }
@@ -7,6 +9,7 @@ declare namespace node {
     value: T;
     left: Instance<T> | null;
     right: Instance<T> | null;
+    readonly degree: Degree;
     isInternal(): boolean;
     isLeaf(): boolean;
   }


### PR DESCRIPTION
## Description

The PR introduces the following accessor method: 

- `Node#degree`

The methods return the degree of the node instance, which can be: `0`, `1` or `2`.

Also, the corresponding TypeScript ambient declarations are included in the PR.
