### PR TITLE
Add new `Tree#remove(value)` class method (#3)

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -34,6 +34,45 @@ class Tree {
     }
   }
 
+  _min(node) {
+    let min = node;
+
+    while (min.left) {
+      min = min.left;
+    }
+
+    return min;
+  }
+
+  _remove(value, node) {
+    if (value < node.value) {
+      node.left = this._remove(value, node.left);
+      return node;
+    }
+
+    if (value > node.value) {
+      node.right = this._remove(value, node.right);
+      return node;
+    }
+
+    if (node.isLeaf()) {
+      return null;
+    }
+
+    if (!node.left) {
+      return node.right;
+    }
+
+    if (!node.right) {
+      return node.left;
+    }
+
+    const successor = this._min(node.right);
+    node.value = successor.value;
+    node.right = this._remove(successor.value, node.right);
+    return node;
+  }
+
   includes(value) {
     let {_root: current} = this;
 
@@ -88,6 +127,16 @@ class Tree {
     }
 
     return min;
+  }
+
+  remove(value) {
+    const {_root} = this;
+
+    if (_root) {
+      this._root = this._remove(value, _root);
+    }
+
+    return this;
   }
 
   search(value) {

--- a/types/bstrie.d.ts
+++ b/types/bstrie.d.ts
@@ -27,6 +27,7 @@ declare namespace tree {
     isEmpty(): boolean;
     max(): node.Instance<T> | null;
     min(): node.Instance<T> | null;
+    remove(value: T): this;
     search(value: T): node.Instance<T> | null;
   }
 }


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Tree#remove(value)`

The method removes the input value from the binary search tree and returns the tree itself.

Also, the corresponding TypeScript ambient declarations are included in the PR.
