### PR TITLE
Add new `Tree#outOrder(fn)` class method (#3)

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -147,11 +147,19 @@ class Tree {
     return min;
   }
 
-  remove(value) {
-    const {_root} = this;
+  outOrder(fn) {
+    const stack = [];
+    let {_root: current} = this;
 
-    if (_root) {
-      this._root = this._remove(value, _root);
+    while (current || stack.length > 0) {
+      if (current) {
+        stack.push(current);
+        current = current.right;
+      } else {
+        current = stack.pop();
+        fn(current.value);
+        current = current.left;
+      }
     }
 
     return this;
@@ -175,6 +183,16 @@ class Tree {
           stack.push(current.left);
         }
       }
+    }
+
+    return this;
+  }
+
+  remove(value) {
+    const {_root} = this;
+
+    if (_root) {
+      this._root = this._remove(value, _root);
     }
 
     return this;

--- a/types/bstrie.d.ts
+++ b/types/bstrie.d.ts
@@ -30,6 +30,7 @@ declare namespace tree {
     isEmpty(): boolean;
     max(): node.Instance<T> | null;
     min(): node.Instance<T> | null;
+    outOrder(fn: UnaryCallback<T>): this;
     preOrder(fn: UnaryCallback<T>): this;
     remove(value: T): this;
     search(value: T): node.Instance<T> | null;


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Tree#outOrder(fn)`

The method traverses the binary search tree in an out-order fashion and applies the `fn` function to the value of each traversed node. At the end of the traversal, the method returns the tree itself.

Also, the corresponding TypeScript ambient declarations are included in the PR.
