### PR TITLE
Add new `Tree#postOrder(fn)` class method (#3)

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -165,6 +165,30 @@ class Tree {
     return this;
   }
 
+  postOrder(fn) {
+    let last = null;
+    const stack = [];
+    let {_root: current} = this;
+
+    while (current || stack.length > 0) {
+      if (current) {
+        stack.push(current);
+        current = current.left;
+      } else {
+        const recent = stack[stack.length - 1];
+
+        if (recent.right && recent.right !== last) {
+          current = recent.right;
+        } else {
+          fn(recent.value);
+          last = stack.pop();
+        }
+      }
+    }
+
+    return this;
+  }
+
   preOrder(fn) {
     let {_root: current} = this;
 

--- a/types/bstrie.d.ts
+++ b/types/bstrie.d.ts
@@ -31,6 +31,7 @@ declare namespace tree {
     max(): node.Instance<T> | null;
     min(): node.Instance<T> | null;
     outOrder(fn: UnaryCallback<T>): this;
+    postOrder(fn: UnaryCallback<T>): this;
     preOrder(fn: UnaryCallback<T>): this;
     remove(value: T): this;
     search(value: T): node.Instance<T> | null;


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Tree#postOrder(fn)`

The method traverses the binary search tree in a post-order fashion and applies the `fn` function to the value of each traversed node. At the end of the traversal, the method returns the tree itself.

Also, the corresponding TypeScript ambient declarations are included in the PR.
