### PR TITLE
Add new `Tree#levelOrder(fn)` class method (#3)

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -123,6 +123,30 @@ class Tree {
     return !this.root;
   }
 
+  levelOrder(fn) {
+    let {_root: current} = this;
+
+    if (current) {
+      const queue = [];
+      queue.push(current);
+
+      while (queue.length > 0) {
+        current = queue.shift();
+        fn(current.value);
+
+        if (current.left) {
+          queue.push(current.left);
+        }
+
+        if (current.right) {
+          queue.push(current.right);
+        }
+      }
+    }
+
+    return this;
+  }
+
   max() {
     let {_root: max} = this;
 

--- a/types/bstrie.d.ts
+++ b/types/bstrie.d.ts
@@ -28,6 +28,7 @@ declare namespace tree {
     inOrder(fn: UnaryCallback<T>): this;
     insert(...values: T[]): this;
     isEmpty(): boolean;
+    levelOrder(fn: UnaryCallback<T>): this;
     max(): node.Instance<T> | null;
     min(): node.Instance<T> | null;
     outOrder(fn: UnaryCallback<T>): this;


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Tree#levelOrder(fn)`

The method traverses the binary search tree in a right-to-left level-order fashion (BFT) and applies the `fn` function to the value of each traversed node. At the end of the traversal, the method returns the tree itself.

Also, the corresponding TypeScript ambient declarations are included in the PR.
