### PR TITLE
Add new `Tree#height()` class method (#3)

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -73,6 +73,37 @@ class Tree {
     return node;
   }
 
+  height() {
+    let height = -1;
+    let {_root: current} = this;
+
+    if (current) {
+      const queue = [];
+      queue.push(current);
+
+      while (queue.length > 0) {
+        height += 1;
+        let nodes = queue.length;
+
+        while (nodes > 0) {
+          current = queue.shift();
+
+          if (current.left) {
+            queue.push(current.left);
+          }
+
+          if (current.right) {
+            queue.push(current.right);
+          }
+
+          nodes--;
+        }
+      }
+    }
+
+    return height;
+  }
+
   includes(value) {
     let {_root: current} = this;
 

--- a/types/bstrie.d.ts
+++ b/types/bstrie.d.ts
@@ -24,6 +24,7 @@ declare namespace tree {
 
   export interface Instance<T> {
     readonly root: node.Instance<T> | null;
+    height(): number;
     includes(value: T): boolean;
     inOrder(fn: UnaryCallback<T>): this;
     insert(...values: T[]): this;


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Tree#height()`

The method returns the maximum distance of any node from the root, also knows as the height of the binary search tree. If the tree is empty `-1` is returned.

Also, the corresponding TypeScript ambient declarations are included in the PR.
