### PR TITLE
Add new `Node#height()` class method (#3)

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -45,6 +45,35 @@ class Node {
     this._value = value;
   }
 
+  height() {
+    let height = -1;
+    let current = this;
+
+    const queue = [];
+    queue.push(current);
+
+    while (queue.length > 0) {
+      height += 1;
+      let nodes = queue.length;
+
+      while (nodes > 0) {
+        current = queue.shift();
+
+        if (current.left) {
+          queue.push(current.left);
+        }
+
+        if (current.right) {
+          queue.push(current.right);
+        }
+
+        nodes--;
+      }
+    }
+
+    return height;
+  }
+
   isInternal() {
     return this.left !== null || this.right !== null;
   }

--- a/types/bstrie.d.ts
+++ b/types/bstrie.d.ts
@@ -10,6 +10,7 @@ declare namespace node {
     left: Instance<T> | null;
     right: Instance<T> | null;
     readonly degree: Degree;
+    height(): number;
     isInternal(): boolean;
     isLeaf(): boolean;
   }


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Node#height()`

The method returns the number of edges from the `Node` instance to the deepest leaf node. The maximum distance from the `root` node to the deepest leaf node is the height of the tree.

Also, the corresponding TypeScript ambient declarations are included in the PR.
