### PR TITLE
Add new `Node#isPartial()` class method (#3)

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -85,6 +85,10 @@ class Node {
   isLeaf() {
     return !this.left && !this.right;
   }
+
+  isPartial() {
+    return this.degree === 1;
+  }
 }
 
 module.exports = Node;

--- a/types/bstrie.d.ts
+++ b/types/bstrie.d.ts
@@ -14,6 +14,7 @@ declare namespace node {
     isFull(): boolean;
     isInternal(): boolean;
     isLeaf(): boolean;
+    isPartial(): boolean;
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Node#isPartial()`

The methods return `true` if the node instance is a partial node (has only one non-null child), or `false` if it is a leaf or full node.

Also, the corresponding TypeScript ambient declarations are included in the PR.
