### PR TITLE
Add new `Node#isRightPartial()` class method (#3)

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -93,6 +93,11 @@ class Node {
   isPartial() {
     return this.degree === 1;
   }
+
+  isRightPartial() {
+    return !this.left && this.right !== null;
+  }
+
 }
 
 module.exports = Node;

--- a/types/bstrie.d.ts
+++ b/types/bstrie.d.ts
@@ -16,6 +16,7 @@ declare namespace node {
     isLeaf(): boolean;
     isLeftPartial(): boolean;
     isPartial(): boolean;
+    isRightPartial(): boolean;
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Node#isRightPartial()`

The methods return `true` if the node instance is a right-partial node (has only one non-null right child), or `false` if it is a leaf, a full or a left partial node.

Also, the corresponding TypeScript ambient declarations are included in the PR.
