### PR TITLE
Add new `Node#children()` class method (#3)

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -45,6 +45,20 @@ class Node {
     this._value = value;
   }
 
+  children() {
+    const children = [];
+
+    if (this.left) {
+      children.push(this.left);
+    }
+
+    if (this.right) {
+      children.push(this.right);
+    }
+
+    return children;
+  }
+
   height() {
     let height = -1;
     let current = this;

--- a/types/bstrie.d.ts
+++ b/types/bstrie.d.ts
@@ -10,6 +10,7 @@ declare namespace node {
     left: Instance<T> | null;
     right: Instance<T> | null;
     readonly degree: Degree;
+    children(): Instance<T>[];
     height(): number;
     isFull(): boolean;
     isInternal(): boolean;


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Node#children()`

The method returns an array contacting the children of the parent Node instance, where the left child, if present, is the first element of the array, and the right child, if present, is the last element of the array.

Also, the corresponding TypeScript ambient declarations are included in the PR.
