### PR TITLE
Add new `Tree#internals()` class method (#3)

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -131,6 +131,18 @@ class Tree {
     return this;
   }
 
+  internals() {
+    let internals = 0;
+
+    this.inOrder(x => {
+      if (x.isInternal()) {
+        internals++;
+      }
+    })
+
+    return internals;
+  }
+
   isComplete() {
     let {_root: current} = this;
 

--- a/types/bstrie.d.ts
+++ b/types/bstrie.d.ts
@@ -36,6 +36,7 @@ declare namespace tree {
     includes(value: T): boolean;
     inOrder(fn: UnaryCallback<Node<T>>): this;
     insert(...values: T[]): this;
+    internals(): number;
     isComplete(): boolean;
     isEmpty(): boolean;
     isFull(): boolean;


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Tree#internals()`

The method returns the number of internal nodes (non-leaf nodes) residing in the binary search tree.

Also, the corresponding TypeScript ambient declarations are included in the PR.
