### PR TITLE
Add new `Tree#toPairs()` class method

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -438,6 +438,12 @@ class Tree {
     this.inOrder(node => array.push(node));
     return array;
   }
+
+  toPairs() {
+    const array = [];
+    this.inOrder(node => array.push(node.toPair()));
+    return array;
+  }
 }
 
 module.exports = Tree;

--- a/test/empty.js
+++ b/test/empty.js
@@ -109,3 +109,7 @@ test('size', t => {
 test('toArray', t => {
   t.deepEqual(tree.toArray(), []);
 });
+
+test('toPairs', t => {
+  t.deepEqual(tree.toPairs(), []);
+});

--- a/test/multiple.js
+++ b/test/multiple.js
@@ -202,3 +202,7 @@ test('toArray', t => {
   const array = tree.toArray();
   t.deepEqual(array.map(x => [x.key, x.value]), [[3, 'D'], [5, 'B'], [7, 'E'], [10, 'A'], [12, 'F'], [15, 'C'], [17, 'G']]);
 });
+
+test('toPairs', t => {
+  t.deepEqual(tree.toPairs(), [[3, 'D'], [5, 'B'], [7, 'E'], [10, 'A'], [12, 'F'], [15, 'C'], [17, 'G']]);
+});

--- a/test/single.js
+++ b/test/single.js
@@ -146,3 +146,10 @@ test('toArray', t => {
   t.deepEqual(tree.toArray(), [tree.root]);
   t.deepEqual(tree.toArray(), [node]);
 });
+
+test('toPairs', t => {
+  const node = new Node(10, 'A');
+  t.deepEqual(tree.toPairs(), [[10, 'A']]);
+  t.deepEqual(tree.toPairs(), [node.toPair()]);
+  t.deepEqual(tree.toPairs(), [tree.root.toPair()]);
+});

--- a/types/binstree.d.ts
+++ b/types/binstree.d.ts
@@ -58,6 +58,7 @@ declare namespace tree {
     search(key: number): Node<T> | null;
     size(): number;
     toArray(): Node<T>[];
+    toPairs(): [number, T][];
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Tree#toPairs()`

Applies in-order traversal to the tree and for each traversed node stores in an `n`-tuple, where `n` the size of the tree, an ordered-pair/2-tuple, where the first element is a `number` corresponding to the `key` of the traversed node, and the last one is a value of type `any`, corresponding to the `value` stored in the traversed node.
The `n`-tuple is returned at the end of the traversal.

Also, the corresponding TypeScript ambient declarations & test cases are included in the PR.
